### PR TITLE
DoCommand() Component Implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules/
 .env
 .env-gl
 .DS_Store
-.env_blank
-.env_raspmodbus
+.env*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 .env
 .env-gl
 .DS_Store
+.env_blank
+.env_raspmodbus

--- a/src/components/do-command.tsx
+++ b/src/components/do-command.tsx
@@ -1,4 +1,4 @@
-import { RobotClient, SensorClient } from "@viamrobotics/sdk";
+import { RobotClient, SensorClient, type StructType } from "@viamrobotics/sdk";
 import type { ResourceName } from "@viamrobotics/sdk/dist/gen/common/v1/common_pb";
 import {
   useEffect,
@@ -41,8 +41,9 @@ export function DoCommand(props: DoCommandProps): JSX.Element {
       return;
     }
     const componenClient = new SensorClient(machineClient, selectedResource);
+    let parsed = JSON.parse(command);
     componenClient
-      .doCommand({ command })
+      .doCommand(parsed as StructType)
       .then((response) => {
         setResult(JSON.stringify(response));
       })

--- a/src/components/do-command.tsx
+++ b/src/components/do-command.tsx
@@ -37,6 +37,7 @@ export function DoCommand(props: DoCommandProps): JSX.Element {
   }, []);
 
   const onSubmit: FormEventHandler = (event) => {
+    event.preventDefault();
     if (!machineClient) {
       return;
     }
@@ -45,12 +46,12 @@ export function DoCommand(props: DoCommandProps): JSX.Element {
     componenClient
       .doCommand(parsed as StructType)
       .then((response) => {
+        console.log(response);
         setResult(JSON.stringify(response));
       })
       .catch((error) => {
         setResult("error: " + error.message);
       });
-    event.preventDefault();
   };
 
   const handleCommand: ChangeEventHandler<HTMLTextAreaElement> = (event) => {

--- a/src/components/do-command.tsx
+++ b/src/components/do-command.tsx
@@ -42,9 +42,15 @@ export function DoCommand(props: DoCommandProps): JSX.Element {
       return;
     }
     const componenClient = new SensorClient(machineClient, selectedResource);
-    let parsed = JSON.parse(command);
+    let parsedCommand;
+    try {
+      parsedCommand = JSON.parse(command);
+    } catch (error) {
+      setResult("error: failed to parse command as JSON");
+      return;
+    }
     componenClient
-      .doCommand(parsed as StructType)
+      .doCommand(parsedCommand as StructType)
       .then((response) => {
         console.log(response);
         setResult(JSON.stringify(response));

--- a/src/components/realtime-data.tsx
+++ b/src/components/realtime-data.tsx
@@ -39,24 +39,29 @@ export const SensorChart = (props: SensorChartProps): JSX.Element => {
   useEffect(() => {
     const sensorClient = new SensorClient(machineClient, config.sensorName);
     const intervall = setInterval(() => {
-      sensorClient?.getReadings().then((reading) => {
-        const sensorReading: SensorReading = { timestamp: new Date() };
-        // Extract values from sensor reading
-        for (const key in reading) {
-          if (reading[key] && typeof reading[key] === "number") {
-            sensorReading[key] = reading[key];
+      sensorClient
+        ?.getReadings()
+        .then((reading) => {
+          const sensorReading: SensorReading = { timestamp: new Date() };
+          // Extract values from sensor reading
+          for (const key in reading) {
+            if (reading[key] && typeof reading[key] === "number") {
+              sensorReading[key] = reading[key];
+            }
           }
-        }
-        // Update readings
-        setReadings((prevData) => {
-          const newData = [...prevData];
-          if (newData.length >= bufferSize) {
-            newData.shift();
-          }
-          newData.push(...[sensorReading]);
-          return newData;
+          // Update readings
+          setReadings((prevData) => {
+            const newData = [...prevData];
+            if (newData.length >= bufferSize) {
+              newData.shift();
+            }
+            newData.push(...[sensorReading]);
+            return newData;
+          });
+        })
+        .catch((error) => {
+          console.error(error);
         });
-      });
     }, intervalMS);
 
     return () => clearInterval(intervall);


### PR DESCRIPTION
You can now call the DoCommand() API of a sensor component directly from the UI. If you need it for another component or service simply change the code accordingly (1. change the resource filter and SensorClient towards your needs.